### PR TITLE
Fix Mongo init and path imports

### DIFF
--- a/server/mongo.ts
+++ b/server/mongo.ts
@@ -1,23 +1,32 @@
 import { MongoClient, Db, Collection, type Document } from "mongodb";
-import 'dotenv/config'
+import "dotenv/config";
 
-
-const uri = process.env.MONGO_URI as string;
-const client: MongoClient = new MongoClient(uri);
+// The Mongo client should not be instantiated until the connection URI is
+// available. In tests the `MONGO_URI` environment variable is set after this
+// module is imported, so lazily create the client when `connect()` is called.
+let client: MongoClient | null = null;
 
 // Connect to MongoDB
-export async function connect(): Promise<void> {
+export async function connect(uri: string = process.env.MONGO_URI as string): Promise<void> {
   try {
+    if (!uri) {
+      throw new Error("MONGO_URI not provided");
+    }
+    client = new MongoClient(uri);
     await client.connect();
     console.log("Connected to MongoDB");
   } catch (err: any) {
     console.error("MongoDB connection error:", err);
+    throw err;
   }
 }
 
 // Get the database (optionally pass a name here if you don't want the default)
 export function getDb(): Db {
-  return client.db('groceries_db');
+  if (!client) {
+    throw new Error("MongoClient not initialized. Call connect() first.");
+  }
+  return client.db("groceries_db");
 }
 
 // Generic helper to get a collection

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,13 @@ import { createServer, type Server } from "http";
 import { WebSocketServer, WebSocket } from "ws";
 import { Server as SocketIOServer } from "socket.io";
 import { storage } from "./storage";
-import { insertGroceryListSchema, insertGroceryItemSchema, insertInventoryItemSchema } from "@shared/schema";
+// Use a relative import so tests running in Node can resolve the module without
+// relying on TypeScript path mappings.
+import {
+  insertGroceryListSchema,
+  insertGroceryItemSchema,
+  insertInventoryItemSchema,
+} from "../shared/schema";
 import { ZodError } from "zod";
 
 type WebSocketMessage = {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -5,7 +5,7 @@ import {
   type InsertGroceryList,
   type InsertGroceryItem,
   type InsertInventoryItem,
-} from "@shared/schema";
+} from "../shared/schema";
 import { nanoid } from "nanoid";
 import { getCollection, getDb } from "./mongo";
 


### PR DESCRIPTION
## Summary
- defer MongoDB client creation until `connect()` is called
- use relative paths for shared schema in server code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f548c5e1083289bed9d98695eeb71